### PR TITLE
Complete pt_br localization and fix divine_protection variable

### DIFF
--- a/common/src/main/resources/assets/paladins/lang/pt_br.json
+++ b/common/src/main/resources/assets/paladins/lang/pt_br.json
@@ -1,9 +1,11 @@
 {
   "itemGroup.paladins.general": "Paladinos & Sacerdotes",
-
   "item.paladins.spell_book/paladin": "Tomo de paladino",
   "item.paladins.spell_book/priest": "Livro sagrado",
-
+  "item.paladins.spell_scroll/paladin": "Pergaminho de Paladino",
+  "item.paladins.spell_scroll/priest": "Pergaminho Sagrado",
+  "item.paladins.spell_book/paladin.spell_binding.description": "Tomo dos Paladinos, que usam armas e feitiços para atacar inimigos e apoiar aliados\n- Pontos fortes: Versátil em batalha, capaz de curar, golpear e defender\n- Pontos fracos: Ataques à distância e mobilidade limitados\n- Equipamento: Armadura pesada",
+  "item.paladins.spell_book/priest.spell_binding.description": "Livro Sagrado dos Sacerdotes, que usam magia sagrada para curar aliados e ferir inimigos\n- Pontos fortes: Apoiar e curar aliados, destruir mortos-vivos\n- Pontos fracos: Baixo dano e defesa física fraca\n- Equipamento: Armadura leve",
   "item.paladins.paladin_armor_head": "Capacete de paladino",
   "item.paladins.paladin_armor_chest": "Peitoral de paladino",
   "item.paladins.paladin_armor_legs": "Calças de paladino",
@@ -16,7 +18,6 @@
   "item.paladins.netherite_crusader_armor_chest": "Peitoral de cruzado de netherite",
   "item.paladins.netherite_crusader_armor_legs": "Calças de cruzado de netherite",
   "item.paladins.netherite_crusader_armor_feet": "Botas de cruzado de netherite",
-
   "item.paladins.stone_claymore": "Claymore de pedra",
   "item.paladins.iron_claymore": "Claymore de ferro",
   "item.paladins.golden_claymore": "Claymore de ouro",
@@ -24,7 +25,7 @@
   "item.paladins.netherite_claymore": "Claymore de netherite",
   "item.paladins.aeternium_claymore": "Claymore de aeternium",
   "item.paladins.ruby_claymore": "Claymore de rubi",
-
+  "item.paladins.aether_claymore": "Claymore Sagrada",
   "item.paladins.wooden_great_hammer": "Grande martelo de madeira",
   "item.paladins.stone_great_hammer": "Grande martelo de pedra",
   "item.paladins.iron_great_hammer": "Grande martelo de ferro",
@@ -33,7 +34,7 @@
   "item.paladins.netherite_great_hammer": "Grande martelo de netherite",
   "item.paladins.aeternium_great_hammer": "Grande martelo de aeternium",
   "item.paladins.ruby_great_hammer": "Grande martelo de rubi",
-
+  "item.paladins.aether_great_hammer": "Grande Martelo da Valquíria",
   "item.paladins.stone_mace": "Clava de pedra",
   "item.paladins.iron_mace": "Clava de ferro",
   "item.paladins.golden_mace": "Clava de ouro",
@@ -41,7 +42,7 @@
   "item.paladins.netherite_mace": "Clava de netherite",
   "item.paladins.aeternium_mace": "Clava de aeternium",
   "item.paladins.ruby_mace": "Clava de rubi",
-
+  "item.paladins.aether_mace": "Clava do Sol",
   "item.paladins.priest_robe_head": "Gola de sacerdote",
   "item.paladins.priest_robe_chest": "Vestuário de sacerdote",
   "item.paladins.priest_robe_legs": "Calças de sacerdote",
@@ -54,28 +55,26 @@
   "item.paladins.netherite_prior_robe_chest": "Vestuário de prior de netherite",
   "item.paladins.netherite_prior_robe_legs": "Calças de prior de netherite",
   "item.paladins.netherite_prior_robe_feet": "Botas de prior de netherite",
-
   "item.paladins.acolyte_wand": "Varinha de acólito",
   "item.paladins.holy_wand": "Varinha sagrada",
   "item.paladins.diamond_holy_wand": "Varinha sagrada de diamante",
   "item.paladins.netherite_holy_wand": "Varinha sagrada de netherite",
-
   "item.paladins.holy_staff": "Cajado sagrado",
   "item.paladins.diamond_holy_staff": "Cajado sagrado de diamante",
   "item.paladins.netherite_holy_staff": "Cajado sagrado de netherite",
   "item.paladins.ruby_holy_staff": "Cajado sagrado de rubi",
-
+  "item.paladins.aether_holy_staff": "Cajado de Prata da Valquíria",
   "item.paladins.iron_kite_shield": "Escudo de pipa de ferro",
   "item.paladins.golden_kite_shield": "Escudo de pipa de ouro",
   "item.paladins.diamond_kite_shield": "Escudo de pipa de diamante",
   "item.paladins.netherite_kite_shield": "Escudo de pipa de netherite",
   "item.paladins.aeternium_kite_shield": "Escudo de pipa de aeternium",
   "item.paladins.ruby_kite_shield": "Escudo de pipa de rubi",
-
+  "item.paladins.aether_kite_shield": "Baluarte da Valquíria",
   "spell.paladins.flash_heal.name": "Cura rápida",
   "spell.paladins.flash_heal.description": "Cura você ou um alvo amigo em {heal} pontos de vida.",
   "spell.paladins.divine_protection.name": "Proteção divina",
-  "spell.paladins.divine_protection.description": "Protege você dos próximos {effect_amplifier} ataques recebidos por {effect_duration} segundos.",
+  "spell.paladins.divine_protection.description": "Protege você dos próximos ataques recebidos (até {effect_amplifier_cap}) por {effect_duration} segundos.",
   "effect.paladins.divine_protection": "Proteção divina",
   "effect.paladins.divine_protection.description": "Protege você do ataque recebido",
   "spell.paladins.judgement.name": "Julgamento",
@@ -86,7 +85,6 @@
   "spell.paladins.battle_banner.description": "Aumenta a velocidade de ataque e a resistência ao empurrão para você e aliados próximos, dentro de {cloud_radius} blocos, por {cloud_duration} segundos.",
   "effect.paladins.battle_banner": "Bandeira de batalha",
   "effect.paladins.battle_banner.description": "Aumenta a velocidade de ataque e a resistência ao empurrão",
-
   "spell.paladins.heal.name": "Cura",
   "spell.paladins.heal.description": "Cura você ou um alvo amigo em {heal} pontos de vida.",
   "spell.paladins.holy_shock.name": "Choque sagrado",
@@ -99,7 +97,6 @@
   "effect.paladins.priest_absorption.description": "Absorve parte do dano que você sofreria.",
   "spell.paladins.barrier.name": "Barreira",
   "spell.paladins.barrier.description": "Convoca uma barreira circular, protegendo você e aliados de projéteis, magia ou inimigos que invadem a área.",
-
   "entity.paladins.barrier": "Barreira",
   "entity.paladins.battle_banner": "Bandeira de batalha",
   "entity.minecraft.villager.monk": "Monge",
@@ -107,22 +104,26 @@
   "entity.minecraft.villager.paladins:monk": "Monge",
   "block.paladins.monk_workbench": "Bancada do monge",
   "block.paladins.monk_workbench.hint": "Bancada para aldeões monges.",
-
   "advancements.rpg_series.path_choose_paladin.title": "Caminho da Justiça",
   "advancements.rpg_series.path_choose_paladin.description": "Crie um Tomo de Paladino",
   "advancements.rpg_series.path_choose_priest.title": "Caminho da Luz",
   "advancements.rpg_series.path_choose_priest.description": "Crie um Livro Sagrado",
-
+  "advancements.rpg_series.spell_cast_paladin_book.title": "Treinamento de Paladino",
+  "advancements.rpg_series.spell_cast_paladin_book.description": "Lance um feitiço do Tomo de Paladino",
+  "advancements.rpg_series.spell_cast_priest_book.title": "Fortalecimento Sagrado",
+  "advancements.rpg_series.spell_cast_priest_book.description": "Lance um feitiço do Livro Sagrado",
+  "advancements.rpg_series.spell_cast_priest_wand.title": "Cura que Conforta",
+  "advancements.rpg_series.spell_cast_priest_wand.description": "Lance um feitiço com uma varinha de cura",
   "advancements.rpg_series.spell_novice_paladin.title": "Defensor ardente",
   "advancements.rpg_series.spell_novice_paladin.description": "Obtenha seu primeiro feitiço de paladino",
   "advancements.rpg_series.spell_novice_priest.title": "Promessa de ascensão",
   "advancements.rpg_series.spell_novice_priest.description": "Obtenha seu primeiro feitiço de sacerdote",
-
   "advancements.rpg_series.spell_master_paladin.title": "Hora do Julgamento",
   "advancements.rpg_series.spell_master_paladin.description": "Obtenha todos os feitiços de paladino",
   "advancements.rpg_series.spell_master_priest.title": "Servo do Ori",
   "advancements.rpg_series.spell_master_priest.description": "Obtenha todos os feitiços de sacerdote",
-
   "advancements.rpg_series.obtain_healing_rune.title": "Caminho da Cura",
-  "advancements.rpg_series.obtain_healing_rune.description": "Obtenha uma Runa de Cura"
+  "advancements.rpg_series.obtain_healing_rune.description": "Obtenha uma Runa de Cura",
+  "advancements.rpg_series.trade_with_monk.title": "Comércio de Curandeiros",
+  "advancements.rpg_series.trade_with_monk.description": "Compre um item de um aldeão Monge"
 }


### PR DESCRIPTION
Completes the Brazilian Portuguese translation for Paladins & Priests (was 110/127, now 127/127).

New strings: the paladin/priest spell scrolls, the aether-tier weapons and shield (Holy Claymore, Valkyrie Great Hammer, Sun's Mace, Silver Staff of the Valkyrie, Valkyrie Bulwark), the two spell book class descriptions, and the `rpg_series` advancements (casting, healing wand, trading with the Monk villager).

I also fixed one existing entry: `divine_protection.description` used `{effect_amplifier}`, but `en_us` now uses `{effect_amplifier_cap}`, which left the variable unresolved in game. Reworded to match the current `en_us` phrasing.

Terminology follows the file's existing choices (Paladino, Sacerdote, Tomo de paladino, Livro sagrado). Placeholders preserved.
