### PR TITLE
Fix dedicated server crash caused by eager SpellTooltip loading

### DIFF
--- a/common/src/main/java/net/paladins/content/PaladinSpells.java
+++ b/common/src/main/java/net/paladins/content/PaladinSpells.java
@@ -875,8 +875,7 @@ public class PaladinSpells {
     private static Entry lightwell() {
         var id = Identifier.of(PaladinsMod.ID, "lightwell");
         var title = "Lightwell";
-        var description = "Summons a Lightwell that heals you and nearby wounded allies. It lasts "
-                + SpellTooltip.placeholder(SpellTooltip.summonDurationToken) + " sec.";
+        var description = "Summons a Lightwell that heals you and nearby wounded allies. It lasts {summon_duration} sec.";
 
         var spell = SpellBuilder.createSpellActive();
         spell.school = SpellSchools.HEALING;


### PR DESCRIPTION
## Problem

`PaladinSpells` builds the Lightwell spell description by calling `SpellTooltip.placeholder(SpellTooltip.summonDurationToken)` during static initialization. `SpellTooltip` lives in Spell Engine's client package and references `MinecraftClient.player` (`ClientPlayerEntity`), so merely loading the class on a dedicated server throws:

```
java.lang.RuntimeException: Cannot load class net.minecraft.client.network.ClientPlayerEntity in environment type SERVER
```

Since spell registration runs on both sides, this crashes dedicated server startup. (Same root cause as the equivalent fix submitted to the Wizards repo: ZsoltMolnarrr/Wizards#100.)

## Fix

Inline the literal `{summon_duration}` placeholder token instead of calling `SpellTooltip.placeholder()`, matching the style already used for other tokens in this file (e.g. `{damage}`). Since `placeholder(x)` just returns `"{" + x + "}"` and the token constant is a compile-time-inlined string, the resulting description is byte-for-byte identical — tooltips and generated lang files are unaffected.

The remaining `SpellTooltip.DescriptionMutator` references are type-only and don't trigger class loading on the server.

Tested: `:common:compileJava` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LFdyAZFXxXc47kHi7iioE